### PR TITLE
Alter rubocop rules for specs

### DIFF
--- a/rubocop_defaults.yml
+++ b/rubocop_defaults.yml
@@ -46,3 +46,12 @@ RSpec/MultipleExpectations:
     - spec/**/*
 RSpec/ExampleLength:
   Max: 15
+  Exclude:
+    - spec/features/**/*_spec.rb
+RSpec/ScatteredSetup:
+  Enabled: false
+RSpec/ReturnFromStub:
+  EnforcedStyle: block
+Style/BlockDelimiters:
+  Exclude:
+    - spec/**/*_spec.rb

--- a/rubocop_defaults.yml
+++ b/rubocop_defaults.yml
@@ -48,10 +48,6 @@ RSpec/ExampleLength:
   Max: 15
   Exclude:
     - spec/features/**/*_spec.rb
-RSpec/ScatteredSetup:
-  Enabled: false
-RSpec/ReturnFromStub:
-  EnforcedStyle: block
 Style/BlockDelimiters:
   Exclude:
     - spec/**/*_spec.rb


### PR DESCRIPTION
This follows on from a number of linter changes I made in https://github.com/switcher-ie/broadband-leads/commit/2477b464c0108ca2b285807c2329f27f9eb926f9. I believe they're reasonable (although there are a couple which I can only justify as personal preference).

I've opened this PR to enable the discussion. If we don't make these changes, I'll go back to `broadband-leads` to correct the style there.

---

`RSpec/ExampleLength` disable example length for feature specs. The whole purpose of a feature spec is to perform a number of actions.

`Style/BlockDelimiters` although I generally agree with this, this disables it for spec files to allow `expect` with block syntax. For example:

```
expect {
  ...
}.to raise_error(NotImplementedError)
```